### PR TITLE
remove sceptre validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,5 @@ jobs:
     - stage: validate
       script: cfn-lint ./templates/**/*.yaml
     - stage: deploy
-      script:
-        - sceptre validate prod
-        - sceptre launch prod --yes
+      script: sceptre launch prod --yes
 


### PR DESCRIPTION
sceptre validation cannot be run because the `validate` command does
not run the cmd hooks to download the actual CF templates from S3
bucket.